### PR TITLE
fix: add deletion info in edit app page

### DIFF
--- a/lib/admin_web/live/app_instance_live/form.ex
+++ b/lib/admin_web/live/app_instance_live/form.ex
@@ -35,19 +35,30 @@ defmodule AdminWeb.AppInstanceLive.Form do
         <.input field={@form[:name]} type="text" label="Name" />
         <.input field={@form[:description]} type="text" label="Description" />
         <.input field={@form[:url]} type="text" label="Url" placeholder="https://example.com" />
-        <.input field={@form[:key]} type="text" label="Key" />
-        <.button
-          class="btn btn-soft btn-primary mb-3"
-          type="button"
-          phx-click="generate_key"
-        >
-          Generate key
-        </.button>
+        <div class="flex flex-row gap-2 items-end w-full">
+          <.input field={@form[:key]} type="text" label="Key" />
+          <.button
+            class="btn btn-soft btn-primary mb-3"
+            type="button"
+            phx-click="generate_key"
+          >
+            Generate key
+          </.button>
+        </div>
         <footer>
           <.button phx-disable-with="Saving..." variant="primary">Save App instance</.button>
           <.button navigate={return_path(@current_scope, @return_to, @app_instance)}>Cancel</.button>
         </footer>
       </.form>
+      <div role="alert" class="alert alert-info alert-soft">
+        <.icon name="hero-information-circle" class="w-6 h-6" />
+        <span>
+          To delete the app go to
+          <.link navigate={return_path(@current_scope, "show", @app_instance)} class="link">
+            the display page
+          </.link>
+        </span>
+      </div>
     </Layouts.app>
     """
   end


### PR DESCRIPTION
In this PR I update the edit app page to include a hint on where to delete the app. 
While using the app it was not very clear to me where I could delete an app. I was in the edit view and was missing the feature.

<img width="1292" height="731" alt="Screenshot 2025-10-06 at 08 58 21" src="https://github.com/user-attachments/assets/ffb79a01-7fab-47ec-a9f2-a58e41dbdbbe" />

I also move the "Generate key" button to the right of the field to make it prettier.